### PR TITLE
Add passport as a dep of passport-localapikey-update

### DIFF
--- a/nodePackages/passport-localapikey-update/0.5.0.nix
+++ b/nodePackages/passport-localapikey-update/0.5.0.nix
@@ -7,6 +7,7 @@ buildNodePackage {
       sha1 = "e7203e4e768277eee803b71193c0617a83d26264";
     };
     deps = with nodePackages; [
+      passport
       passport-strategy_1-0-0
       pkginfo_0-2-3
     ];


### PR DESCRIPTION
@adnelson On github, passport is listed as a dev dependency of passport-localapikey-update, but I get an error when client-cluster-server tries to import the passport-localapikey-update module if it's not packaged with the passport module.
